### PR TITLE
clustergram 0.8.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,6 @@ requirements:
     # mkl variant pulls in intel-openmp which conflicts with llvm-openmp. i.e. force to use openblas variant of numpy, scipy, etc.
     - blas=*=openblas  # [osx and x86_64]
 test:
-    - clustergram/test_clustergram.py
   imports:
     - clustergram
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "clustergram" %}
+{% set version = "0.8.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/clustergram-{{ version }}.tar.gz
+  sha256: 0766a804781e5616baf2492ff10d4a40d6261abee87ae6e707601fe3300c7573
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  skip:  # [py>38]
+
+requirements:
+  host:
+    - python
+    - setuptools >=61.0
+    - wheel
+    - setuptools-scm >=6.2
+    - pip
+  run:
+    - python
+    - pandas
+    - numpy
+    - matplotlib-base
+
+test:
+  source_files:
+    - clustergram/test_clustergram.py
+  imports:
+    - clustergram
+  commands:
+    - pip check
+    - pytest -v clustergram/test_clustergram.py
+  requires:
+    - pip
+    - pytest
+    - bokeh
+    - scikit-learn
+
+about:
+  summary: Clustergram - visualization and diagnostics for cluster analysis
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - psteyer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
     - clustergram
   commands:
     - pip check
-    - pytest -v clustergram/test_clustergram.py
+    - pytest -v clustergram/test_clustergram.py -k "not test_sklearn_kmeans"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - clustergram
   commands:
     - pip check
-    - pytest -v clustergram/test_clustergram.py
+    - pytest -v --pyargs clustergram
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,9 +42,18 @@ test:
     - scikit-learn
 
 about:
+  home: https://github.com/martinfleis/clustergram
   summary: Clustergram - visualization and diagnostics for cluster analysis
+  description: |
+    This is a Python implementation, originally based on Tal's script, written 
+    for scikit-learn and RAPIDS cuML implementations of K-Means, Mini Batch K-Means 
+    and Gaussian Mixture Model (scikit-learn only) clustering, plus hierarchical/agglomerative 
+    clustering using SciPy.
   license: MIT
+  licese_family: MIT
   license_file: LICENSE
+  dev_url: https://github.com/martinfleis/clustergram
+  doc_url: https://clustergram.readthedocs.io/en/stable/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ test:
     - clustergram
   commands:
     - pip check
-    - pytest -v clustergram/test_clustergram.py -k "not test_sklearn_kmeans"
+    - pytest -v clustergram/test_clustergram.py
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ about:
     and Gaussian Mixture Model (scikit-learn only) clustering, plus hierarchical/agglomerative 
     clustering using SciPy.
   license: MIT
-  licese_family: MIT
+  license_family: MIT
   license_file: LICENSE
   dev_url: https://github.com/martinfleis/clustergram
   doc_url: https://clustergram.readthedocs.io/en/stable/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,6 @@ requirements:
     # mkl variant pulls in intel-openmp which conflicts with llvm-openmp. i.e. force to use openblas variant of numpy, scipy, etc.
     - blas=*=openblas  # [osx and x86_64]
 test:
-  source_files:
     - clustergram/test_clustergram.py
   imports:
     - clustergram

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,12 +21,15 @@ requirements:
     - wheel
     - setuptools-scm >=6.2
     - pip
+    # mkl variant pulls in intel-openmp which conflicts with llvm-openmp. i.e. force to use openblas variant of numpy, scipy, etc.
+    - blas=*=openblas  # [osx and x86_64]
   run:
     - python
     - pandas
     - numpy
     - matplotlib-base
-
+    # mkl variant pulls in intel-openmp which conflicts with llvm-openmp. i.e. force to use openblas variant of numpy, scipy, etc.
+    - blas=*=openblas  # [osx and x86_64]
 test:
   source_files:
     - clustergram/test_clustergram.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ about:
   license_family: MIT
   license_file: LICENSE
   dev_url: https://github.com/martinfleis/clustergram
-  doc_url: https://clustergram.readthedocs.io/en/stable/
+  doc_url: https://clustergram.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
clustergram 0.8.1 :snowflake:

**Destination channel:** Snowflake 

### Links

- [PKG-4542](https://anaconda.atlassian.net/browse/PKG-4542) 
- [Upstream repository](https://github.com/martinfleis/clustergram/tree/v0.8.1)


### Explanation of changes:

- initial recipe creation and package build
- added `openblas` force due to `Fatal Python error: Segmentation fault` on `osx-64`


[PKG-4542]: https://anaconda.atlassian.net/browse/PKG-4542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ